### PR TITLE
Update 3.1.2-Working-with-JdbcTemplate.md

### DIFF
--- a/cn-translate/Chapter-03/3.1-Reading-and-writing-data-with-JDBC/3.1.2-Working-with-JdbcTemplate.md
+++ b/cn-translate/Chapter-03/3.1-Reading-and-writing-data-with-JDBC/3.1.2-Working-with-JdbcTemplate.md
@@ -99,7 +99,7 @@ public class JdbcIngredientRepository implements IngredientRepository {
 
 可以看到，JdbcIngredientRepository 使用了 `@Repository` 注解。这个注解是 Spring 定义的少数几个原型注解之一，包括 `@Controller` 和 `@Component`。通过使用 `@Repository` 对 JdbcIngredientRepository 进行注解，这样它就会由 Spring 组件在扫描时自动发现，并在 Spring 应用程序上下文中生成 bean 实例。
 
-当 Spring 创建 JdbcIngredientRepository bean 时，通过 `@Autowired` 注解将 JdbcTemplate 注入到 bean 中。如果有多个构造函数，或者如果您只想显式地注入，那么可以使用 `@Autowired`：
+当 Spring 创建 JdbcIngredientRepository bean 时，Spring会向bean注入JdbcTemplate.这是因为该类只有一个构造方法，Spring会通过构造方法的参数来隐式调用自动装配依赖。如果类里的构造方法不止一个，或者你想让构造方法被显式地自动装配，那么你需要在构造方法上添加@Autowired注解。
 
 ```java
 @Autowired


### PR DESCRIPTION
原文：When Spring creates the  JdbcIngredientRepository  bean, it injects it with  JdbcTemplate.That’s  because  when  there’s  only  one  constructor,  Spring  implicitly  applies  autowiring  of dependencies through that constructor’s parameters. If there were more than one constructor, or if you just want autowiring to be explicitly stated, then you can annotated the constructor with  @Autowired.
这里缺少了前半部分的翻译。