### PR TITLE
Update 3.3.4-Customizing-repositories.md

### DIFF
--- a/cn-translate/Chapter-03/3.3-Persisting-data-with-Spring-Data-JPA/3.3.4-Customizing-repositories.md
+++ b/cn-translate/Chapter-03/3.3-Persisting-data-with-Spring-Data-JPA/3.3.4-Customizing-repositories.md
@@ -66,7 +66,7 @@ List<TacoOrder> findByDeliveryCityOrderByDeliveryTo(String city);
 虽然命名约定对于相对简单的查询很有用，但是对于更复杂的查询，不需要太多的想象就可以看出方法名称可能会失控。在这种情况下，可以随意将方法命名为任何想要的名称，并使用 `@Query` 对其进行注解，以显式地指定调用方法时要执行的查询，如下例所示：
 
 ```java
-@Query("Order o where o.deliveryCity='Seattle'")
+@Query("select o from TacoOrder o where o.deliveryCity='Seattle'")
 List<TacoOrder> readOrdersDeliveredInSeattle();
 ```
 


### PR DESCRIPTION
@Query中的sql语句错误，在编辑器里报错。正确格式该是：select o from TacoOrder o where o.deliveryCity='Seattle'